### PR TITLE
Fix - prevent negative string length if cannot find ?

### DIFF
--- a/src/New-LogicAppDoc.ps1
+++ b/src/New-LogicAppDoc.ps1
@@ -231,7 +231,7 @@ $objects | Group-Object -Property Type | ForEach-Object {
             $value = $childAction.Value
             if ($name -eq 'Http') {
                 $guid = New-Guid
-                $value = $value.SubString(0, [math]::min($value.IndexOf("?"),$value.length))
+                $value = $value.SubString([math]::min([math]::max($value.IndexOf("?"),0),$value.length))
                 $calloutGraph += "      $guid$ (`"$value`")"  + [Environment]::NewLine
             } else {
                 if ($value -eq '') { $value = $childAction.ActionName}


### PR DESCRIPTION
Fix an error where if the URL does not contain a ?, then it returns -1 which is an invalid index length into the string.  This code resolves this.