### PR TITLE
Add - Add expression (if syntax) to workflow actions table

### DIFF
--- a/src/Helper.ps1
+++ b/src/Helper.ps1
@@ -118,8 +118,14 @@ Function Get-Action {
         $inputs = if ($action | Get-Member -MemberType Noteproperty -Name 'inputs') { 
             $($action.inputs)
         } 
-        else { 
-            $null 
+        else {
+            # If there is an expression section, then likely an If statement
+            if ($action | Get-Member -MemberType Noteproperty -Name 'expression') { 
+                $($action.expression)
+            } 
+            else {
+                $null 
+            }
         }
 
         $type = $action.type

--- a/src/LogicApp.Doc.ps1
+++ b/src/LogicApp.Doc.ps1
@@ -42,8 +42,8 @@ $($InputObject.diagram)
         Section 'Actions' {            
             $($InputObject.actions) |                 
             Sort-Object -Property Order |  
-            Select-Object -Property 'ActionName', 'Comment', 'Type', 'RunAfter', @{Name = 'Inputs'; Expression = { Format-MarkdownTableJson -Json $($_.Inputs | ConvertFrom-Json | ConvertTo-Json -Depth 10)} } |
-            Table -Property 'ActionName', 'Comment', 'Type', 'RunAfter', 'Inputs'            
+            Select-Object -Property 'ActionName', 'Comment', 'Type', 'RunAfter', @{Name = 'Inputs/Expressions'; Expression = { Format-MarkdownTableJson -Json $($_.Inputs) } } |
+            Table -Property 'ActionName', 'Comment', 'Type', 'RunAfter', 'Inputs/Expressions' 
         }
     }
 


### PR DESCRIPTION
The current implementation does not show the definition of the _If_ statement which when reading makes it difficult to understand the flow.  This PR add this to the _Inputs_ table.