### PR TITLE
Feature standard logic app documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This solution contains scripts to generate technical documentation for <u>Azure 
 This project uses GitHub Issues to track bugs and feature requests.
 Please search the existing issues before filing new issues to avoid duplicates.
 
-- For new issues, file your bug or feature request as a new [issue](https://github.com/stefanstranger/logicappdocs/issues).
+- For new issues, file your bug or feature request as a new [issue](https://github.com/gooseleggs/logicappdocs/issues).
   - If you can please add the Logic App Code (json content), cleared with any sensitive information to the issue if possible.
-- For help, discussion, and support questions about using this project, join or start a [discussion](https://github.com/stefanstranger/logicappdocs/discussions).
+- For help, discussion, and support questions about using this project, join or start a [discussion](https://github.com/gooseleggs/logicappdocs/discussions).
 
 Support for this project is limited to the resources listed above.
 
@@ -19,10 +19,15 @@ Clone the repository and run the script. The script will prompt you for the para
 
 ```powershell
 # Clone the repository
-git clone https://github.com/stefanstranger/logicappdocs.git
+git clone https://github.com/gooseleggs/logicappdocs.git
 ```
 
-## Run the New-LogicAppDoc.ps1 PowerShell script to create the Markdown file for an Azure Logic App
+There are two scripts that can be used for Logic apps
+ 
+ - New-LogicAppDoc.ps1 - original script with modifications - used when documenting consumption logic apps
+ - New-StandardLogicApp.ps1 - Used for documenting standard logic apps
+
+## Run the New-LogicAppDoc.ps1 PowerShell script to create the Markdown file for a consumption Azure Logic App
 
 Navigate to the folder where you have cloned the repository and run the New-LogicAppDoc.ps1 script.
 
@@ -41,6 +46,7 @@ Login-AzAccount -SubscriptionId <SubscriptionId>
 <img src="./images/logicappscript.png" alt="Powershell script screenshot of New-LogicAppDoc.ps1 script running in console" width="1200">
 
 ### Command line options
+
  | parameter | type | default | description |
  | --- | --- | --- | --- |
  | replaceU0027  | Bool | false | Removes U0027 characters from output |
@@ -54,6 +60,26 @@ Login-AzAccount -SubscriptionId <SubscriptionId>
  | LogicAppName | String | | Name of the logic app |
  | OutputPath | String | | Output file directory |
 
+## Run the New-StandardLogicApp.ps1 PowerShell script to create the Markdown file for a standard Azure Logic App
+
+Navigate to the folder where you have cloned the repository and run the New-StandardLogicApp.ps1 script.
+
+```powershell
+# Authenticate to Azure where the Azure Logic App is located
+Login-AzAccount -SubscriptionId <SubscriptionId>
+
+# Run the script
+# Example:
+#   .\src\New-StandardLogicApp.ps1 -SubscriptionId 'dfc1f10c-a847-4250-bde8-93c3d6c53ea0' -ResourceGroupName 'jiraintegration-demo-rg' -LogicAppName 'logic-jiraintegration-demo' -Location 'Australia-East' -WorkingDirectory "C:\Temp\logicApp\source" -OutputPath 'C:\Temp\logicApp\md" 
+ .\src\New-StandardLogicApp.ps1 -SubscriptionId *SubscriptionID* -ResourceGroupName *ResourceGroupName* -LogicAppName *LogicAppName* -Location *AzureLocationName* -WorkingDirectory *Directory_to_store_definition_files* -OutputPath *Direction_to_store_markdown_files*
+```
+This version of the script usings a working directory to download the defintion files for the workflows.  The output markdown is then written to another directory, along with a start file that provides an index for the workflows.
+
+It is highly suggested that the *workingDirectory* and the *OutputPath* are different directories.
+
+The script will remove workflow definitions that are no longer defined for the logic app from the source directory.
+
+The list of workflows in the start page contains when the source file was last modified by this script, and NOT by the logic app.
 
 
 ## Run the New-PowerAutomateDoc.ps1 PowerShell script to create the Markdown file for a Power Automate Flow

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Go to the directory where you have saved the Markdown file (OutputPath) and open
 
 ## Credits
 
+Thanks to [Stefan Stranger](https://github.com/stefanstranger) for creating the original script.  I just extended it after getting no response to pull requests.
+
 Special thanks and shoutouts to [Prateek Singh](https://github.com/PrateekKumarSingh) for his [Azure Visualizer tool](https://github.com/PrateekKumarSingh/AzViz). I used some of his code and inspiration to develop the LogicAppDocs script.
 
 [Rick Strahl](https://twitter.com/rickstrahl) with some Markdown tips and tricks and for creating the awesome [Markdown Monster](https://store.west-wind.com/product/markdown_monster_3) Editor, Viewer and Weblog Publisher for Windows.
@@ -131,10 +133,10 @@ And finally some great PowerShell community members for their feedback and sugge
 
 ## Change Log
 
-*V1.2.0 - TO BE RELEASED
+*V1.2.0 - TO BE RELEASED (Release Branch)
 * Added call out graph
 * Merge of Confluence pull request from upstream repository
-* 
+* Can document standard logic apps
 * Bug Fixes
   * Fix length problem for actionName < 5 characters
   * Fix count problems 
@@ -194,7 +196,7 @@ If you are ready to contribute, please visit the [contribution guide](CONTRIBUTI
 
 ## Maintainers
 
-- [Stefan Stranger](https://github.com/stefanstranger)
+- [Gooseleggs](https://github.com/gooseleggs)
 
 ## License
 

--- a/src/LogicApp.Cover.Doc.ps1
+++ b/src/LogicApp.Cover.Doc.ps1
@@ -1,0 +1,78 @@
+Document 'Azure-Standard-LogicApp-Documentation' {
+
+    # Helper function
+    Function Format-MarkdownTableJson {
+        [CmdletBinding()]
+        Param(
+            [Parameter(Mandatory = $true)]
+            $Json
+        )
+
+        ("<table><tr><td><pre>$Json</pre></td></tr></table>") -replace '\r\n', '<br>'
+    }
+
+    # Formats JSON in a nicer format than the built-in ConvertTo-Json does.
+    function Format-Json([Parameter(Mandatory, ValueFromPipeline)][String] $json) {
+        $indent = 0;
+        ($json -Split '\n' |
+        % {
+            if ($_ -match '[\}\]]') {
+                # This line contains  ] or }, decrement the indentation level
+                if ($indent) {
+                    $indent--
+                }
+            }
+            $line = (' ' * $indent * 2) + $_.TrimStart().Replace(':  ', ': ')
+            if ($_ -match '[\{\[]') {
+                # This line contains [ or {, increment the indentation level
+                $indent++
+            }
+            $line
+        }) -Join "`n"
+    }
+
+    "# Azure Logic App Documentation - $($InputObject.LogicApp.name)"
+
+    Section 'Introduction' {
+        "This document describes the Standard Azure Logic App **$($InputObject.LogicApp.name)** in the **$($InputObject.LogicApp.ResourceGroupName)** resource group in the **$($InputObject.LogicApp.SubscriptionName)** subscription."
+        "This document is programmatically generated using a PowerShell script."
+        
+        "Date: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
+    }
+   
+    Section 'Workflows' {
+        "This section details the workflows defined within the logic App."
+
+        "**NOTE** The LastWriteTime is when the file was last updated from the Logic App AND NOT when the logic app was updated."
+
+        Section 'Workflows' {
+            $($InputObject.LogicApp.Workflows) |
+            Select-Object -Property @{Name = 'Workflow'; Expression = { "[$($_.Name)]($($InputObject.LogicApp.OutputPath)$($_.Name).md)"  }}, LastWriteTime |
+            Table -Property 'Workflow', 'LastWriteTime'
+
+        }
+
+    }
+
+    Section 'Parameters' {
+        "This section shows the parameters defined within the logic App"
+
+        Section 'Parameters' {
+            $($InputObject.LogicApp.Parameters) |
+            Select-Object -Property 'Name', 'Type', 'Value' |
+            Table -Property 'Name', 'Type', 'Value'
+        }
+    }
+
+    if ($InputObject.Connections) {
+        Section 'Logic App Connections' {
+            "This section shows an overview of Logic App Workflow connections."
+
+            Section 'Connections' {
+                $($InputObject.Connections) |
+                Select-Object -Property 'ConnectionName', 'ConnectionId', @{Name = 'ConnectionProperties'; Expression = { Format-MarkdownTableJson -Json $($_.ConnectionProperties | ConvertTo-Json | Format-Json) } } |
+                Table -Property 'ConnectionName', 'ConnectionId', 'ConnectionProperties'
+            }
+        }
+    }
+}

--- a/src/New-StandardLogicApp.ps1
+++ b/src/New-StandardLogicApp.ps1
@@ -1,0 +1,351 @@
+<#
+    Script to test the PowerShell script New-LogicAppDoc.ps1 using a json file with the Logic App Workflow configuration
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]
+    $SubscriptionId, 
+
+    [Parameter(Mandatory=$true)]
+    [string]
+    $ResourceGroupName, 
+
+    [Parameter(Mandatory=$false)]
+    [string]
+    $LogicAppName,
+
+    [Parameter(Mandatory=$false)]
+    [string]
+    $WorkingDirectory,
+
+    [Parameter(Mandatory = $true,
+    ParameterSetName = 'Local')]
+    [string]$Location,
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputPath = (Get-Location).Path,
+
+    [Parameter(Mandatory = $false,
+    ParameterSetName = 'Local')]
+    [string]$FilePath,    
+
+    [Parameter(Mandatory = $false)]
+    [boolean]$ConvertToADOMarkdown = $false,
+    
+    [Parameter(Mandatory = $false)]
+    [bool] $replaceU0027 = $false,
+    
+    [Parameter(Mandatory = $false)]
+    [bool]$Show = $false    
+)
+
+#region Import PowerShell Modules. Add more modules if needed
+if (Get-Module -ListAvailable -Name PSDocs) {
+    Write-Verbose -Message 'PowerShell Module PSDocs is already installed'
+}
+else {
+    Write-Verbose 'Installing PowerShell Module PSDocs'
+    Install-Module PSDocs -RequiredVersion 0.9.0 -Scope CurrentUser -Repository PSGallery -SkipPublisherCheck -Confirm:$false -Force | Out-Null
+}
+#endregion
+
+#region dot source Helper Functions
+. (Join-Path $PSScriptRoot 'Helper.ps1')
+#endregion
+
+#region Set Variables
+$templateName = 'Azure-LogicApp-Documentation'
+$templatePath = (Join-Path $PSScriptRoot 'LogicApp.Doc.ps1')
+$templateStandardName = 'Azure-Standard-LogicApp-Documentation'
+$templateStandardPath = (Join-Path $PSScriptRoot 'LogicApp.Cover.Doc.ps1')
+#$SubscriptionId = 'Unknown'
+#$SubscriptionName = 'Unknown'
+#$ResourceGroupName = 'Unknown'
+#$LogicAppName = 'Unknown'
+#endregion
+
+#region Helper Functions
+
+# From PowerShell module AzViz. (https://raw.githubusercontent.com/PrateekKumarSingh/AzViz/master/AzViz/src/private/Test-AzLogin.ps1)
+Function Test-AzLogin {
+    [CmdletBinding()]
+    [OutputType([boolean])]
+    [Alias()]
+    Param()
+
+    Begin {
+    }
+    Process {
+        # Verify we are signed into an Azure account
+        try {
+            try {
+                Import-Module Az.Accounts -Verbose:$false   
+            }
+            catch {}
+            Write-Verbose 'Testing Azure login'
+            $isLoggedIn = [bool](Get-AzContext -ErrorAction Stop)
+            if (!$isLoggedIn) {                
+                Write-Verbose 'Not logged into Azure. Initiate login now.'
+                Write-Host 'Enter your credentials in the pop-up window' -ForegroundColor Yellow
+                $isLoggedIn = Connect-AzAccount
+            }
+        }
+        catch [System.Management.Automation.PSInvalidOperationException] {
+            Write-Verbose 'Not logged into Azure. Initiate login now.'
+            Write-Host 'Enter your credentials in the pop-up window' -ForegroundColor Yellow
+            $isLoggedIn = Connect-AzAccount
+        }
+        catch {
+            Throw $_.Exception.Message
+        }
+        [bool]$isLoggedIn
+    }
+    End {
+        
+    }
+}
+#endregion
+
+# Given a list of files, delete folders that are not in the list
+function Compare-And-Delete {
+    param (
+        [string]$SourceList,
+        [string]$TargetDir
+    )
+
+    # Get the list of folders in the target directory
+    $targetFolders = Get-ChildItem -Path $TargetDir -Directory
+
+    # Compare and delete folders in the target directory that are not in the source directory
+    foreach ($folder in $targetFolders) {
+        if (-not $sourceFolderNames.ContainsKey($folder.Name)) {
+            Remove-Item -Path $folder.FullName -Recurse -Force
+            Write-Output "Deleted folder: $($folder.FullName)"
+        }
+    }
+}
+
+#region Get Logic App Workflow code
+if (!($FilePath)) {
+
+    Write-Host ('Getting Logic App Workflow code for Logic App "{0}" in Resource Group "{1}" and Subscription "{2}"' -f $LogicAppName, $ResourceGroupName, $(Get-AzContext).Subscription.Name) -ForegroundColor Green
+
+    # Test if the user is logged in
+    if (!(Test-AzLogin)) {
+        break
+    }
+
+    $SubscriptionName = (Get-AzContext).Subscription.Name
+
+    $files = "host.json", "connections.json", "parameters.json"
+    Write-Output $files
+
+    # Download Files
+    $files | ForEach-Object {
+        $hostFile = Invoke-AzRestMethod `
+            -Uri "https://$LogicAppName.scm.azurewebsites.net/api/vfs/site/wwwroot/$_" `
+            -ResourceId "https://management.azure.com/" 
+        if ($hostFile.StatusCode -eq 200) {
+            $writeFile = $true
+            if (Test-Path -Path $workingDirectory/$_ -PathType leaf) {
+                $file = (Get-Content $workingDirectory/$_ -Raw).Trim()
+                $writeFile = !(Compare-FileChecksumOfStrings -sourceString ($hostFile.Content).Trim() -TargetString ($file ))
+            }
+            if ($writeFile) {
+                Write-output "$file definition differs from local copy - updating"
+                $hostFile.Content > "$WorkingDirectory/$_"
+            }
+        } else {
+            Write-Output "Download failed for $_"
+            Write-Output $hostFile.Content
+            exit
+        }
+    }
+
+    # Create a hash set of source folder names for quick lookup
+    $sourceFolderNames = @{}
+
+    $workflows = Invoke-AzRestMethod `
+        -Path "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.Web/sites/$LogicAppName/workflows?api-version=2018-11-01"
+    $workflowsObject = $workflows.Content | ConvertFrom-Json
+    $workflowsObject.value | ForEach-Object {
+        $name = $_.name -replace '.*/'
+        Write-host "  Downloading definition for $name" -ForegroundColor Green
+        $hostFile = Invoke-AzRestMethod `
+            -Uri "https://$LogicAppName.scm.azurewebsites.net/api/vfs/site/wwwroot/$name/workflow.json" `
+            -ResourceId "https://management.azure.com/" 
+        $writeFile = $true
+        if (Test-Path -Path $WorkingDirectory/$name/workflow.json -PathType leaf) {
+            $writeFile = !(Compare-FileChecksumOfStrings -sourceString ($hostFile.Content).Trim() -TargetString (Get-Content $WorkingDirectory/$name/workflow.json -Raw).Trim())
+        }
+        if ($writeFile) {
+            Write-output "$name Logic app workflow differs from local copy - updating"
+            New-Item -Path "$WorkingDirectory/$name/workflow.json" -ItemType File -Force | Out-Null
+            $hostFile.Content > "$WorkingDirectory/$name/workflow.json"
+        }
+        $sourceFolderNames[$name] = $true
+    }
+
+    # Remove folders that we have not downloaded this time
+    Compare-And-Delete -SourceList $sourceFolderNames -TargetDir $WorkingDirectory
+
+    # Write out a definition file in case we read it back
+    "{`"SubscriptionID`": `"$SubscriptionId`", `"SubscriptionName`": `"$SubscriptionName`",`"ResourceGroupName`": `"$ResourceGroupName`",`"LogicAppName`": `"$LogicAppName`"}" | ConvertFrom-Json | ConvertTo-JSON > "$WorkingDirectory/logicApp.json"
+    Write-Host "Finished Downloading"
+
+} else {
+    # Say that we are using a working directory
+    Write-Output -InputObject ('Using Logic App Workflow code from Folder "{0}"' -f $FilePath)
+
+    # Standardize on WorkingDirectory variable
+    $WorkingDirectory = $FilePath
+}
+
+# Now we have (hopefully) a populated folder, lets get down to work
+
+# Lets see if the defintion file exists
+if (Test-Path -Path "$WorkingDirectory/logicApp.json" -PathType Leaf) {
+
+    # If it does...read in the variables and continue
+    $json = Get-Content -Path "$WorkingDirectory/logicApp.json" | ConvertFrom-JSON
+
+    # Set the variables
+    $SubscriptionId = $json.SubscriptionID
+    $SubscriptionName = $json.SubscriptionName
+    $ResourceGroupName = $json.ResourceGroupName
+    $LogicAppName = $json.LogicAppName
+} else {
+    # ... else ah oh - time to quit
+    Write-Host 'Cannot find logicApp.json - quitting' -ForegroundColor Yellow
+    exit
+ }
+
+# Lets see if the parameters file exists
+if (Test-Path -Path "$WorkingDirectory/parameters.json" -PathType Leaf) {
+
+    # If it does...read in the variables and continue
+    $LAParameters = Get-Content -Path "$WorkingDirectory/parameters.json" -Raw| ConvertFrom-JSON
+    # Convert the hashtable to a custom object and then to a table  
+    $LAParameters = $LAParameters.PSObject.Properties | ForEach-Object {
+        [PSCustomObject]@{
+            Name = $_.Name
+            Type      = $_.Value.type
+            Value     = $_.Value.value
+        }
+    }
+} else {
+    # ... else ah oh - time to quit
+    Write-Host 'Cannot find parameters.json - quitting' -ForegroundColor Yellow
+    exit
+}    
+
+ 
+$workflows = Get-ChildItem -Path  "$WorkingDirectory" -Directory | Select-Object Name, LastWriteTime
+
+# Get all subfolders
+$subfolders = Get-ChildItem -Path $WorkingDirectory -Directory
+
+# Initialize an array to store the results
+$workflows = @()
+
+# Loop through each subfolder
+foreach ($folder in $subfolders) {
+    # Define the path to the workflow.json file
+    $workflowFilePath = Join-Path -Path $folder.FullName -ChildPath "workflow.json"
+    
+    # Check if the workflow.json file exists
+    if (Test-Path -Path $workflowFilePath) {
+        # Get the modification date of the workflow.json file
+        $modificationDate = (Get-Item -Path $workflowFilePath).LastWriteTime
+        
+        # Create a PSCustomObject with the folder name and modification date
+        $workflow = [PSCustomObject]@{
+            Name            = $folder.Name
+            LastWriteTime   = $modificationDate
+        }
+        
+        # Add the result to the array
+        $workflows += $workflow
+    }
+}
+
+# Ensure that the output directory exists
+if (! (Test-Path -Path $outputPath -PathType Container)) {
+    New-Item -Path $outputPath -ItemType Directory -Force
+}
+
+$OutputPath = "$OutputPath\$LogicAppName"
+
+# Temporary store path as we need to reset it after each invocation of New-LogicAppDoc
+$basePath = $OutputPath
+
+# Temporary variable as $logicAppName updated during dot sourcing 
+$LogicAppNameStored = $LogicAppName
+
+
+# Iterate over all directory paths and create output for workflows
+ Get-ChildItem -Path "$WorkingDirectory" -Directory | 
+ Foreach-Object {
+     $wfName =  $_.Name
+
+     $params = @{
+         SubscriptionName = $SubscriptionName
+         ResourceGroupName = $ResourceGroupName
+         Location         = $Location
+         FilePath         = "$WorkingDirectory/$wfName/workflow.json"
+         LogicAppName     = $wfName
+         OutputPath       = "$outputPath\$wfName.md"
+         Verbose          = $false
+         Debug            = $false
+         ConvertToADOMarkdown = $false
+         Show             = $false
+         replaceU0027        = $true
+     }
+
+     write-host "Output path is $outputPath\$LogicAppName\$wfName.md"
+     write-Host "==================================================="
+     Write-host "Processing $WorkingDirectory/$wfName/workflow.json"
+     write-Host "==================================================="
+     . ..\src\New-LogicAppDoc.ps1 @params
+
+    # Reset the path
+    $OutputPath = $basePath
+ }
+
+
+# Create an Index document
+
+#region Generate Cover Markdown documentation for Standard Logic App Workflow
+$InputObject = [pscustomobject]@{
+    'LogicApp'       = [PSCustomObject]@{
+        Name              = $LogicAppNameStored
+        ResourceGroupName = $resourceGroupName
+        Location          = $Location
+        SubscriptionName  = $SubscriptionName
+        Parameters        = $LAParameters
+        Workflows         = $workflows
+    }
+
+#    'Parameters'     = $LAParameters
+#    'Connections'    = $Connections
+}
+
+write-Host "==================================================="
+Write-host "Creating Start document"
+write-Host "==================================================="
+
+$options = New-PSDocumentOption -Option @{ 'Markdown.UseEdgePipes' = 'Always'; 'Markdown.ColumnPadding' = 'Single' };
+$null = [PSDocs.Configuration.PSDocumentOption]$Options
+$invokePSDocumentSplat = @{
+    Path         = $templateStandardPath
+    Name         = $templateStandardName
+    InputObject  = $InputObject
+    Culture      = 'en-us'
+    Option       = $options
+    InstanceName = $LogicAppNameStored
+}
+
+$markDownFile = Invoke-PSDocument @invokePSDocumentSplat
+$markDownFile | set-content -path "$outputPath/start.md" -force -NoNewline -Encoding ASCII
+


### PR DESCRIPTION
This feature creates a cover page for Logic Apps on the Standard tier.  It allows connection to Azure to pull down the workflows.  The cover page includes the connections, and a link to each to workflow.  If a workflow is removed from Azure, then the definition file is removed from the local repository.  For each workflow, the last modified timestamp of the file on disk is used, and not the last time it is modified on Azure it is not always correct in my quick checking.